### PR TITLE
add ignore to options + default ignore paths that contains 'node_modules...

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -61,6 +61,27 @@ module.exports = function(grunt) {
         'tmp/test-package-v.json'
       ]
     },
+    ignore_default: {
+      options: {
+          pkg: grunt.file.readJSON('test/fixtures/test-package.json')
+      },
+      src: [
+        'tmp/456.js',
+        'tmp/node_modules/test-package.json'
+      ]
+    },
+    ignore_list: {
+      options: {
+        pkg: grunt.file.readJSON('test/fixtures/test-package.json'),
+        release: 'minor',
+        ignore: ['ignored_dir', 'node_modules']
+      },
+      src: [
+        'tmp/456.js',
+        'tmp/node_modules/test-package.json',
+        'tmp/ignored_dir/test-package.json',
+      ]
+    }
   };
 
   // Project configuration.
@@ -84,11 +105,10 @@ module.exports = function(grunt) {
     copy: {
       tests: {
         files: [{
-          src: ['test/fixtures/*'],
+          cwd: 'test/fixtures/',
+          src: ['**'],
           dest: 'tmp/',
-          filter: 'isFile',
-          expand: true,
-          flatten: true
+          expand: true
         }]
       }
     },

--- a/test/fixtures/ignored_dir/test-package.json
+++ b/test/fixtures/ignored_dir/test-package.json
@@ -1,0 +1,46 @@
+{
+  "name": "grunt-version",
+  "0.1.18": "Handle versioning of a project.",
+  "version": "0.1.0",
+  "homepage": "https://github.com/kswedberg/grunt-version",
+  "0.1.18": {
+    "name": "Karl Swedberg",
+    "email": "kswedberg@gmail.com",
+    "url": "http://karlswedberg.com/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/kswedberg/grunt-version.git"
+  },
+  "bugs": {
+    "url": "https://github.com/kswedberg/grunt-version/issues"
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://github.com/kswedberg/grunt-version/blob/master/LICENSE-MIT"
+    }
+  ],
+  "main": "Gruntfile.js",
+  "engines": {
+    "node": ">= 0.8.0"
+  },
+  "scripts": {
+    "test": "grunt test"
+  },
+  "dependencies": {
+    "semver": "~1.1.3"
+  },
+  "devDependencies": {
+    "grunt-contrib-jshint": "0.1.1rc6",
+    "grunt-contrib-clean": "0.4.0rc6",
+    "grunt-contrib-nodeunit": "0.1.2rc6",
+    "grunt": "0.4.0rc8",
+    "grunt-version": ">=0.1.0"
+  },
+  "keywords": [
+    "gruntplugin",
+    "version",
+    "0.1.18"
+  ]
+}

--- a/test/version_test.js
+++ b/test/version_test.js
@@ -4,102 +4,140 @@ var semver = require('semver');
 var grunt = require('grunt');
 
 /*
-  ======== A Handy Little Nodeunit Reference ========
-  https://github.com/caolan/nodeunit
+ ======== A Handy Little Nodeunit Reference ========
+ https://github.com/caolan/nodeunit
 
-  Test methods:
-    test.expect(numAssertions)
-    test.done()
-  Test assertions:
-    test.ok(value, [message])
-    test.equal(actual, expected, [message])
-    test.notEqual(actual, expected, [message])
-    test.deepEqual(actual, expected, [message])
-    test.notDeepEqual(actual, expected, [message])
-    test.strictEqual(actual, expected, [message])
-    test.notStrictEqual(actual, expected, [message])
-    test.throws(block, [error], [message])
-    test.doesNotThrow(block, [error], [message])
-    test.ifError(value)
-*/
+ Test methods:
+ test.expect(numAssertions)
+ test.done()
+ Test assertions:
+ test.ok(value, [message])
+ test.equal(actual, expected, [message])
+ test.notEqual(actual, expected, [message])
+ test.deepEqual(actual, expected, [message])
+ test.notDeepEqual(actual, expected, [message])
+ test.strictEqual(actual, expected, [message])
+ test.notStrictEqual(actual, expected, [message])
+ test.throws(block, [error], [message])
+ test.doesNotThrow(block, [error], [message])
+ test.ifError(value)
+ */
 
 exports.version = {
-  setUp: function(done) {
-    done();
-  },
-  prefix_option: function(test) {
-    var files = grunt.config('version.prefix_option.src');
-    test.expect(files.length);
+    setUp: function(done) {
+        done();
+    },
+    prefix_option: function(test) {
+        var files = grunt.config('version.prefix_option.src');
+        test.expect(files.length);
 
-    files.forEach(function(file) {
-      var content = grunt.file.read(file);
-      var actual = /version['"]?\s*[:=] ['"](\d\.\d\.\d)/.exec(content);
-      actual = actual && actual[1];
+        files.forEach(function(file) {
+            var content = grunt.file.read(file);
+            var actual = /version['"]?\s*[:=] ['"](\d\.\d\.\d)/.exec(content);
+            actual = actual && actual[1];
 
-      test.equal(actual, '0.1.0', 'Updates the file with version.');
-    });
-    test.done();
-  },
-  patch: function(test) {
-    var files = grunt.config('version.patch.src');
-    test.expect(files.length);
+            test.equal(actual, '0.1.0', 'Updates the file with version.');
+        });
+        test.done();
+    },
+    patch: function(test) {
+        var files = grunt.config('version.patch.src');
+        test.expect(files.length);
 
-    files.forEach(function(file) {
-      var content = grunt.file.read(file);
-      var actual = /version['"]?\s*[:=] ['"](\d\.\d\.\d)/.exec(content);
-      actual = actual && actual[1];
+        files.forEach(function(file) {
+            var content = grunt.file.read(file);
+            var actual = /version['"]?\s*[:=] ['"](\d\.\d\.\d)/.exec(content);
+            actual = actual && actual[1];
 
-      test.equal(actual, '0.1.1', 'Increments the version and updates the file.');
-    });
+            test.equal(actual, '0.1.1', 'Increments the version and updates the file.');
+        });
 
-    test.done();
-  },
-  prerelease: function(test) {
+        test.done();
+    },
+    prerelease: function(test) {
 
-    var file = grunt.config('version.prerelease.src');
-    var content = grunt.file.read(file);
-    var actual = /version['"]?\s*[:=] ['"](\d\.\d\.\d[\-\+a-zA-Z0-9\.]*)/.exec(content);
-    actual = actual && actual[1];
+        var file = grunt.config('version.prerelease.src');
+        var content = grunt.file.read(file);
+        var actual = /version['"]?\s*[:=] ['"](\d\.\d\.\d[\-\+a-zA-Z0-9\.]*)/.exec(content);
+        actual = actual && actual[1];
 
-    test.expect(1);
-    test.equal(actual, '1.2.3-alpha.0', 'Increments the version and updates the file.');
+        test.expect(1);
+        test.equal(actual, '1.2.3-alpha.0', 'Increments the version and updates the file.');
 
-    test.done();
-  },
-  minor: function(test) {
-    var files = grunt.config('version.minor.src');
-    test.expect(files.length);
+        test.done();
+    },
+    minor: function(test) {
+        var files = grunt.config('version.minor.src');
+        test.expect(files.length);
 
-    files.forEach(function(file) {
-      var content = grunt.file.read(file);
-      var actual = /version['"]?\s*[:=] ['"](\d\.\d\.\d)/.exec(content);
-      actual = actual && actual[1];
+        files.forEach(function(file) {
+            var content = grunt.file.read(file);
+            var actual = /version['"]?\s*[:=] ['"](\d\.\d\.\d)/.exec(content);
+            actual = actual && actual[1];
 
-      test.equal(actual, '1.3.0', 'Increments the version and updates the file.');
-    });
+            test.equal(actual, '1.3.0', 'Increments the version and updates the file.');
+        });
 
-    test.done();
-  },
-  literal: function(test) {
-    test.expect(2);
-    var pkg = grunt.file.readJSON('tmp/test-package-v.json');
+        test.done();
+    },
+    literal: function(test) {
+        test.expect(2);
+        var pkg = grunt.file.readJSON('tmp/test-package-v.json');
 
-    test.equal(pkg.version, '3.2.1', 'Sets package version to literal value');
-    test.equal(pkg.devDependencies['grunt-version'], '>=0.1.0', 'Does NOT increment grunt-version');
-    test.done();
-  },
-  prerelease_build: function(test) {
-    var files = grunt.config('version.prerelease_build.src');
-    test.expect(files.length);
+        test.equal(pkg.version, '3.2.1', 'Sets package version to literal value');
+        test.equal(pkg.devDependencies['grunt-version'], '>=0.1.0', 'Does NOT increment grunt-version');
+        test.done();
+    },
+    prerelease_build: function(test) {
+        var files = grunt.config('version.prerelease_build.src');
+        test.expect(files.length);
 
-    files.forEach(function(file) {
-      var content = grunt.file.read(file);
-      var actual = /version['"]?\s*[:=] ['"]([^'"]+)/.exec(content);
-      actual = actual && actual[1];
+        files.forEach(function(file) {
+            var content = grunt.file.read(file);
+            var actual = /version['"]?\s*[:=] ['"]([^'"]+)/.exec(content);
+            actual = actual && actual[1];
 
-      test.equal(actual, '1.0.0-beta.2', 'Increments the version and updates the file.');
-    });
+            test.equal(actual, '1.0.0-beta.2', 'Increments the version and updates the file.');
+        });
 
-    test.done();
-  }
+        test.done();
+    },
+    ignore_default: function (test) {
+        var files = grunt.config('version.ignore_default.src');
+        test.expect(files.length);
+
+        files.forEach(function(file) {
+            var content = grunt.file.read(file);
+            var actual = /version['"]?\s*[:=] ['"]([^'"]+)/.exec(content);
+            actual = actual && actual[1];
+
+            console.log(file, actual);
+
+            if (file.indexOf('node_modules') !== -1) {
+                test.equal(actual, '0.1.0', 'Files containing node_modules in their path shouldn\'t be updated');
+            } else {
+                test.equal(actual, '0.1.1', 'Update the files to 0.1.0 except those containing node_modules/ in their path');
+            }
+        });
+
+        test.done();
+    },
+    ignore_list: function (test) {
+        var files = grunt.config('version.ignore_list.src');
+        test.expect(files.length);
+
+        files.forEach(function(file) {
+            var content = grunt.file.read(file);
+            var actual = /version['"]?\s*[:=] ['"]([^'"]+)/.exec(content);
+            actual = actual && actual[1];
+
+            if (file.indexOf('node_modules') !== -1 || file.indexOf('ignored_dir') !== -1) {
+                test.equal(actual, '0.1.0', 'Files containing node_modules or ignored_dir in their path shouldn\'t be updated');
+            } else {
+                test.equal(actual, '0.1.1', 'Update the files to 0.1.1 except those containing node_modules/ & ignored_dir in their path');
+            }
+        });
+
+        test.done();
+    }
 };


### PR DESCRIPTION
Hi,

The idea of this Pull Request is to bring an `ignore` option.  
**options.ignore**
Type: Array
Default Value: ['node_modules']

It will ignore any file that contains 'node_modules' within their path
