### PR TITLE
[TASK] Add option for creating prerelease prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Default value: `''`
 
 A string value representing one of the **semver 2.x** release types (`'major'`, `'minor'`, `'patch'`, or `'prerelease'`) used to increment the value of the specified package version. See [node-semver](https://github.com/isaacs/node-semver) for more information about release incrementing. The value may also be a literal semver-valid release (for example, '1.3.2').
 
-#### options.prereleaseidentifier
+#### options.prereleaseIdentifier
 Type: `String`
 Default value: `''`
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ Default value: `''`
 
 A string value representing one of the **semver 2.x** release types (`'major'`, `'minor'`, `'patch'`, or `'prerelease'`) used to increment the value of the specified package version. See [node-semver](https://github.com/isaacs/node-semver) for more information about release incrementing. The value may also be a literal semver-valid release (for example, '1.3.2').
 
+#### options.prereleaseidentifier
+Type: `String`
+Default value: `''`
+
+A string a prefix for the prerelease version (e.g., `'dev'`,`'alpha'`,`'beta'`). Setting this value to `dev` would prerelease-increment a version of 1.2.3 to 1.2.3-dev.0 instead of 1.2.3-0.
+
 ### Usage Examples
 
 #### Default Options

--- a/tasks/version.js
+++ b/tasks/version.js
@@ -74,7 +74,7 @@ module.exports = function(grunt) {
 
     if ( bump && semver.valid(version) ) {
       if (typeof options.prereleaseidentifier !== 'undefined') {
-        newVersion = semver.inc(version, release, options.prereleaseidentifier);
+        newVersion = semver.inc(version, release, options.prereleaseIdentifier);
       } else {
         newVersion = semver.inc(version, release);
       }

--- a/tasks/version.js
+++ b/tasks/version.js
@@ -73,7 +73,11 @@ module.exports = function(grunt) {
         literal = semver.valid(release);
 
     if ( bump && semver.valid(version) ) {
-      newVersion = semver.inc(version, release);
+      if (typeof options.prereleaseidentifier !== 'undefined') {
+        newVersion = semver.inc(version, release, options.prereleaseidentifier);
+      } else {
+        newVersion = semver.inc(version, release);
+      }
     } else if (literal) {
       newVersion = literal;
     } else if (release) {


### PR DESCRIPTION
Wonderful wrapper for semver! I'm just missing out on the prerelease prefix (e.g. alpha, beta, dev). As you just hand over everything to the npm lib, it would just be adding a option and an if clause.